### PR TITLE
Feat/datahp 2h sampling

### DIFF
--- a/experiments/weather/climatology_wb2.py
+++ b/experiments/weather/climatology_wb2.py
@@ -1,0 +1,228 @@
+"""
+WeatherBench2 climatology reader for the 1990-2017 6-hourly dataset.
+
+Zarr layout  (all spatial arrays):  (4, 366, [13,] 512, 256)
+  dim 0  – hour slot  : 0→0 UTC, 1→6 UTC, 2→12 UTC, 3→18 UTC
+  dim 1  – day of year: 1-indexed (1–366), index = doy - 1
+  dim 2  – pressure level (upper-level vars only): ascending hPa [50…1000]
+  dim -2 – longitude  : 512 points  0 → 359.296875°
+  dim -1 – latitude   : 256 points  -89.648° (S) → 89.648° (N)
+
+Model channel ordering
+  surface : [msl, u10, v10, t2m]           shape (4, npix)
+  upper   : [z, q, t, u, v]  levels 1000→50  shape (5, 13, npix)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import zarr
+import healpix as hp
+from pathlib import Path
+
+
+WB2_ZARR_PATH = Path(
+    "/proj/heal_pangu/1990-2017_6h_512x256_equiangular_conservative.zarr/"
+)
+
+# zarr variable name → model channel index for surface
+_SURFACE_VARS = [
+    "mean_sea_level_pressure",    # 0 – msl
+    "10m_u_component_of_wind",    # 1 – u10
+    "10m_v_component_of_wind",    # 2 – v10
+    "2m_temperature",             # 3 – t2m
+]
+
+# zarr variable name → model channel index for upper
+_UPPER_VARS = [
+    "geopotential",               # 0 – z
+    "specific_humidity",          # 1 – q
+    "temperature",                # 2 – t
+    "u_component_of_wind",        # 3 – u
+    "v_component_of_wind",        # 4 – v
+]
+
+# Zarr pressure levels (ascending hPa); model wants descending → reversed
+_ZARR_LEVELS_HPA = [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
+
+
+
+def _precompute_bilinear(lat_grid: np.ndarray, lon_grid: np.ndarray,
+                          nside: int) -> tuple:
+    """
+    Precompute bilinear interpolation indices and weights from a regular
+    lat/lon grid to every HEALPix pixel (nested ordering).
+
+    lat_grid : (H,) ascending latitudes   (degrees, e.g. -89.6 … 89.6)
+    lon_grid : (W,) ascending longitudes  (degrees, e.g. 0 … 359.3)
+
+    Returns six arrays, each of shape (npix,):
+        i0, i1 – lower/upper lat indices   (i1 = i0+1, clamped)
+        j0, j1 – lower/upper lon indices   (j1 wraps for lon periodicity)
+        wy     – weight for i1 (lat fraction)
+        wx     – weight for j1 (lon fraction)
+
+    Interpolated value for a (…, W, H) array `a`:
+        out = a[…, i0, j0]*(1-wx)*(1-wy) + a[…, i0, j1]*wx*(1-wy)
+            + a[…, i1, j0]*(1-wx)*wy     + a[…, i1, j1]*wx*wy
+    """
+    npix = hp.nside2npix(nside)
+    hlon, hlat = hp.pix2ang(nside, np.arange(npix), lonlat=True, nest=True)
+    hlon = np.mod(hlon, 360.0)
+
+    H = len(lat_grid)
+    W = len(lon_grid)
+    dlat = lat_grid[1] - lat_grid[0]
+    dlon = lon_grid[1] - lon_grid[0]
+
+    # Latitude (no wrap; clamp to valid range)
+    lat_frac = (hlat - lat_grid[0]) / dlat
+    i0 = np.clip(np.floor(lat_frac).astype(np.int32), 0, H - 2)
+    wy = np.clip(lat_frac - i0, 0.0, 1.0).astype(np.float32)
+    i1 = i0 + 1
+
+    # Longitude (periodic: wrap at 360°)
+    lon_frac = (hlon - lon_grid[0]) / dlon
+    j0 = np.floor(lon_frac).astype(np.int32) % W
+    wx = (lon_frac - np.floor(lon_frac)).astype(np.float32)
+    j1 = (j0 + 1) % W
+
+    return i0, i1, j0, j1, wy, wx
+
+
+def _apply_bilinear(a: np.ndarray,
+                    i0, i1, j0, j1, wy, wx) -> np.ndarray:
+    """
+    Apply precomputed bilinear weights to array `a`.
+
+    a   : (…, W, H)  – any number of leading dims (channels, levels)
+    out : (…, npix)
+    """
+    return (a[..., j0, i0] * (1 - wx) * (1 - wy)
+          + a[..., j1, i0] *      wx  * (1 - wy)
+          + a[..., j0, i1] * (1 - wx) *      wy
+          + a[..., j1, i1] *      wx  *      wy).astype(np.float32)
+
+
+class WeatherBenchClimatology:
+    """
+    Reads the WeatherBench2 1990-2017 6-hourly climatology zarr and returns
+    surface + upper climate means on the HEALPix grid, normalized with the
+    same statistics as DataHP.
+
+    Usage
+    -----
+    clim = WeatherBenchClimatology(nside=64)
+    surface, upper = clim.get(day_of_year=32, hour_utc=6)
+    # surface: (4, 49152)   upper: (5, 13, 49152)
+    """
+
+    def __init__(self,
+                 nside: int = 64,
+                 normalize: bool = True,
+                 zarr_path: str | Path | None = None):
+        self.nside = nside
+        self.normalize = normalize
+
+        zarr_path = Path(zarr_path) if zarr_path is not None else WB2_ZARR_PATH
+        self._z = zarr.open(str(zarr_path), mode="r")
+
+        lat = self._z["latitude"][:]   # (256,) south→north
+        lon = self._z["longitude"][:]  # (512,) 0→359.3
+
+        # Precompute bilinear interpolation weights once
+        self._i0, self._i1, self._j0, self._j1, self._wy, self._wx = (
+            _precompute_bilinear(lat, lon, nside)
+        )
+
+        if normalize:
+            from experiments.weather.data import deserialize_dataset_statistics
+            self._stats = deserialize_dataset_statistics(nside).item()
+
+
+
+    def get(self, day_of_year: int, hour_utc: int) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Return climatological surface and upper arrays for a given time-of-year.
+
+        Parameters
+        ----------
+        day_of_year : int
+            Day-of-year, 1-indexed (1–366). Feb-29 is valid; if the zarr
+            contains only 365 days the last day is used as a fallback.
+        hour_utc : int
+            Hour in UTC; must be one of {0, 6, 12, 18}.
+
+        Returns
+        -------
+        surface : np.ndarray, shape (4, npix), dtype float32
+            Channels: [msl, u10, v10, t2m].
+        upper : np.ndarray, shape (5, 13, npix), dtype float32
+            Channels: [z, q, t, u, v].
+            Pressure levels (dim 1): [1000, 925, …, 50] hPa.
+        """
+        if hour_utc not in (0, 6, 12, 18):
+            raise ValueError(f"hour_utc must be 0, 6, 12 or 18; got {hour_utc}")
+
+        hour_slot = hour_utc // 6
+        n_days = self._z["dayofyear"].shape[0]
+        day_idx = min(day_of_year - 1, n_days - 1)  # 0-indexed; clamp for 365-day years
+
+        surface = self._read_surface(hour_slot, day_idx)
+        upper   = self._read_upper(hour_slot, day_idx)
+
+        if self.normalize:
+            from experiments.weather.data import normalize_sample
+            surface, upper = normalize_sample(self._stats, surface, upper)
+            surface = surface.astype(np.float32)
+            upper   = upper.astype(np.float32)
+
+        return surface, upper
+
+    def get_from_datetime(self, dt) -> tuple[np.ndarray, np.ndarray]:
+        """Convenience wrapper accepting a datetime object."""
+        from datetime import datetime
+        doy = dt.timetuple().tm_yday
+        # Round hour to nearest 6-h slot
+        hour = (dt.hour // 6) * 6
+        return self.get(day_of_year=doy, hour_utc=hour)
+
+
+    def _read_surface(self, hour_slot: int, day_idx: int) -> np.ndarray:
+        """Return (4, npix) surface array on HEALPix grid (not yet normalized)."""
+        channels = []
+        for var in _SURFACE_VARS:
+            raw = np.array(self._z[var][hour_slot, day_idx], dtype=np.float32)
+            # raw shape: (512, 256) = (lon, lat)
+            channels.append(_apply_bilinear(raw, self._i0, self._i1,
+                                            self._j0, self._j1, self._wy, self._wx))
+        return np.stack(channels, axis=0)  # (4, npix)
+
+    def _read_upper(self, hour_slot: int, day_idx: int) -> np.ndarray:
+        """Return (5, 13, npix) upper array on HEALPix grid (not yet normalized)."""
+        channels = []
+        for var in _UPPER_VARS:
+            raw = np.array(self._z[var][hour_slot, day_idx], dtype=np.float32)
+            # raw shape: (13, 512, 256) = (level, lon, lat)
+            # Zarr levels: ascending hPa [50…1000]; reverse to get [1000…50]
+            raw = raw[::-1].copy()
+            hp_map = _apply_bilinear(raw, self._i0, self._i1,
+                                     self._j0, self._j1, self._wy, self._wx)
+            # hp_map shape: (13, npix)
+            channels.append(hp_map)
+        return np.stack(channels, axis=0)  # (5, 13, npix)
+
+if __name__ == "__main__":
+    from datetime import datetime
+
+    wb = WeatherBenchClimatology()
+    date_1 = datetime(2019, 1, 1, 2)
+    date_2 = datetime(2019, 1, 1, 0)
+    date_3 = datetime(2020, 1, 1, 4)
+    surface_1, upper_1 = wb.get_from_datetime(date_1)
+    surface_2, upper_2 = wb.get_from_datetime(date_2)
+    surface_3, upper_3 = wb.get_from_datetime(date_3)
+
+    # all the surface and upper arrays should be identical since they all round to the same 6-h slot and day of year
+    assert np.allclose(surface_1, surface_2) and np.allclose(surface_1, surface_3)
+    assert np.allclose(upper_1, upper_2) and np.allclose(upper_1, upper_3)

--- a/experiments/weather/data.py
+++ b/experiments/weather/data.py
@@ -1,3 +1,4 @@
+import os
 import time
 import copy
 import json
@@ -8,6 +9,8 @@ from pathlib import Path
 from datetime import datetime, timedelta
 import shutil
 from multiprocessing import Pool
+from datetime import datetime, timedelta
+import tqdm
 
 
 # from lib.models.healpix.swin_hp_transformer import SwinHPTransformerConfig
@@ -37,6 +40,7 @@ ERA5_START_YEAR_TRAINING = 2007
 ERA5_END_YEAR_TRAINING = 2017
 ERA5_START_YEAR_TEST = 2019
 ERA5_END_YEAR_TEST = 2019
+EQUIVAIRIANT_CACHE_YEARS = [2012, 2019]
 
 
 @dataclass
@@ -49,6 +53,8 @@ class DataHPConfig:
     start_year: int = 2007
     end_year: int = 2017
     lead_time_days: int = 1
+
+    delta_t: int = 24 # hours, possilbe choices are 2, 4, 6, 12, 24
 
     def short_name(self):
         return f"era5_{self.start_year}_{self.end_year}"
@@ -70,6 +76,7 @@ class DataHPConfig:
         keys.remove("normalized")
         keys.remove("lead_time_days")
         keys.remove("end_year")
+        keys.remove("delta_t")
         return "_".join([f"{key}_{self.__dict__[key]}" for key in keys])
 
     def cache_name(self):
@@ -77,7 +84,20 @@ class DataHPConfig:
         keys.remove("cache")
         keys.remove("lead_time_days")
         keys.remove("end_year")
+        keys.remove("delta_t")
         return "_".join([f"{key}_{self.__dict__[key]}" for key in keys])
+    
+    def cache_name_equivariant(self):
+        if not self.delta_t in [2, 4, 6, 8, 12, 24]:
+            raise ValueError("delta_t must be one of [2, 4, 6, 8, 12, 24]")
+        
+        if not self.start_year in EQUIVAIRIANT_CACHE_YEARS or not self.end_year in EQUIVAIRIANT_CACHE_YEARS:
+            raise ValueError(f"Equivariant cache is only implemented for the years {EQUIVAIRIANT_CACHE_YEARS}")
+        
+        if self.start_year != self.end_year:
+            raise ValueError("Equivariant cache is only implemented for single year datasets")
+
+        return "era5_lite_equivariant"
 
     def validation(self):
         ret = copy.deepcopy(self)
@@ -99,8 +119,13 @@ class DataHPConfig:
 @dataclass
 class DataSpecHP:
     nside: int
-    n_surface: int
+    n_surface: int    # output (target) surface channels — always 4
     n_upper: int
+    n_surface_in: int = 0  # input surface channels; may exceed n_surface when extra forcing features (e.g. cos SZA) are added
+
+    def __post_init__(self):
+        if self.n_surface_in == 0:
+            self.n_surface_in = self.n_surface
 
 
 def days_between_years(start_year: int, end_year: int) -> int:
@@ -112,7 +137,7 @@ def days_between_years(start_year: int, end_year: int) -> int:
 def days_from_start_year(start_year: int, year: int, month: int, day: int) -> int:
     start_date = datetime(start_year, 1, 1)  # Start of the start year
     specific_date = datetime(year, month, day)  # Specific date
-    return (specific_date - start_date).days
+    return (specific_date - start_date).days 
 
 
 def day_index_to_datetime(day_index: int, start_year: int, end_year: int):
@@ -122,14 +147,14 @@ def day_index_to_datetime(day_index: int, start_year: int, end_year: int):
 
 
 def day_index_to_era5_config(
-    day_index: int, start_year: int, end_year: int
+    day_index: int, start_year: int, end_year: int, time_str: str = "00:00:00"
 ) -> cdstest.ERA5SampleConfig:
     target_date = day_index_to_datetime(day_index, start_year, end_year)
     return cdstest.ERA5SampleConfig(
         year=target_date.strftime("%Y"),
         month=target_date.strftime("%m"),
         day=target_date.strftime("%d"),
-        time="00:00:00",
+        time=time_str,
     )
 
 
@@ -145,15 +170,70 @@ def day_index_to_climatology_indices(day_index, start_year, end_year):
     return indices
 
 
+def index_to_datetime(index: int, config: "DataHPConfig") -> datetime:
+    """Convert a DataHP dataset index to its corresponding input datetime."""
+    if config.delta_t == 24:
+        return day_index_to_datetime(index, config.start_year, config.end_year)
+    raw_2h = index * config.delta_t // 2
+    year_offset = raw_2h // (12 * 365)
+    slot_in_year = raw_2h % (12 * 365)
+    return datetime(config.start_year + year_offset, 1, 1) + timedelta(hours=slot_in_year * 2)
+
+
+def datetime_to_dataset_index(dt: datetime, config: "DataHPConfig") -> int:
+    """Convert a datetime to a DataHP dataset index for the given config."""
+    if config.delta_t == 24:
+        return days_from_start_year(config.start_year, dt.year, dt.month, dt.day)
+    year_offset = dt.year - config.start_year
+    hour_of_year = int((dt - datetime(dt.year, 1, 1)).total_seconds() // 3600)
+    slot_in_year = hour_of_year // 2  # data stored every 2 hours
+    total_2h = year_offset * (12 * 365) + slot_in_year
+    return total_2h * 2 // config.delta_t
+
+
+def index_to_climatology_indices(index: int, data_config: "DataHPConfig", climate_config: "DataHPConfig") -> list:
+    """Return climate dataset indices matching the same time-of-year as `index` in data_config.
+
+    For sub-daily delta_t the hour is also matched; for daily (delta_t=24) only month/day.
+    Feb 29 entries in non-leap training years are silently skipped.
+    """
+    dt = index_to_datetime(index, data_config)
+    match_hour = climate_config.delta_t != 24
+
+    indices = []
+    for year in range(climate_config.start_year, climate_config.end_year + 1):
+        try:
+            if match_hour:
+                target_dt = datetime(year, dt.month, dt.day, dt.hour, 0, 0)
+            else:
+                target_dt = datetime(year, dt.month, dt.day, 0, 0, 0)
+        except ValueError:
+            continue
+        indices.append(datetime_to_dataset_index(target_dt, climate_config))
+    return indices
+
+
+
+
 class Climatology(torch.utils.data.Dataset):
-    def __init__(self, data_config: DataHPConfig):
+    def __init__(self, data_config: DataHPConfig, use_wb2_clim: bool = False):
         self.ds = DataHP(data_config)
-        climate_config = copy.deepcopy(data_config)
-        climate_config.start_year = ERA5_START_YEAR_TRAINING
-        climate_config.end_year = ERA5_END_YEAR_TRAINING
-        self.ds_climate = DataHP(climate_config)
-        self.climate_config = climate_config
         self.config = data_config
+        self.use_wb2_clim = use_wb2_clim
+
+        if use_wb2_clim:
+            from experiments.weather.climatology_wb2 import WeatherBenchClimatology
+            self._wb2_clim = WeatherBenchClimatology(
+                nside=data_config.nside, normalize=True
+            )
+        else:
+            climate_config = copy.deepcopy(data_config)
+            # Force daily resolution: _get_24h treats indices as day-counts, not 2h-slots.
+            # Multi-year datasets can't use the equivariant cache and fall through to _get_24h,
+            # so a sub-daily delta_t here would misinterpret 2h-slot indices as day offsets,
+            # producing dates far in the future and causing CDS API failures.
+            self.ds_climate = DataHP(climate_config)
+            self.climate_config = climate_config
 
     def get_meta(self):
         return self.ds.get_meta()
@@ -162,9 +242,39 @@ class Climatology(torch.utils.data.Dataset):
         return len(self.ds)
 
     def __getitem__(self, index):
+        item_dict = dict(sample_id=index)
+        item_dict.update(self.ds[index])
+
+        if self.use_wb2_clim:
+            dt = index_to_datetime(index, self.config)
+            doy = dt.timetuple().tm_yday
+            hour = (dt.hour // 6) * 6
+
+            cache_root = self.ds.get_cache_dir() / "climate_wb2"
+            cache_dir = cache_root / f"doy{doy:03d}_h{hour:02d}"
+            cache_tmp = cache_root / f"doy{doy:03d}_h{hour:02d}_constructing"
+            surf_path = cache_dir / "climate_target_surface.npy"
+            upper_path = cache_dir / "climate_target_upper.npy"
+
+            if cache_dir.is_dir() and self.config.cache:
+                clim_surface = np.load(surf_path)
+                clim_upper = np.load(upper_path)
+            else:
+                clim_surface, clim_upper = self._wb2_clim.get(doy, hour)
+                if self.config.cache:
+                    cache_tmp.mkdir(parents=True, exist_ok=True)
+                    np.save(cache_tmp / "climate_target_surface.npy", clim_surface)
+                    np.save(cache_tmp / "climate_target_upper.npy", clim_upper)
+                    if not cache_dir.is_dir():
+                        shutil.move(cache_tmp, cache_dir)
+
+            item_dict["climate_target_surface"] = clim_surface.astype(np.float32)
+            item_dict["climate_target_upper"] = clim_upper.astype(np.float32)
+            return item_dict
+
         cache_path = self.ds_climate.get_cache_dir() / "climate"
-        climate_indices = day_index_to_climatology_indices(
-            index, self.climate_config.start_year, self.climate_config.end_year
+        climate_indices = index_to_climatology_indices(
+            index, self.config, self.climate_config
         )
         indices_str = "_".join(map(str, climate_indices))
         fs_cache_path = cache_path / f"{indices_str}"
@@ -173,12 +283,8 @@ class Climatology(torch.utils.data.Dataset):
             climate_target_surface="climate_target_surface.npy",
             climate_target_upper="climate_target_upper.npy",
         )
-        item_dict = dict(
-            sample_id=index,
-        )
         if fs_cache_path.is_dir() and self.config.cache:
             print("Climate cache")
-            item_dict.update(self.ds[index])
             for key, filename in names.items():
                 item_dict[key] = np.load(fs_cache_path / filename).astype(np.float32)
         else:
@@ -195,7 +301,6 @@ class Climatology(torch.utils.data.Dataset):
             for key in accum_dict.keys():
                 accum_dict[key] /= len(climate_indices)
 
-            item_dict.update(self.ds[index])
             item_dict["climate_target_surface"] = accum_dict["target_surface"]
             item_dict["climate_target_upper"] = accum_dict["target_upper"]
             if self.config.cache:
@@ -348,11 +453,24 @@ def numpy_hp_to_e5(
 class DataHP(torch.utils.data.Dataset):
     def __init__(self, data_config: DataHPConfig):
         self.config = data_config
+        self.use_equivariant_cache = self.config.start_year in EQUIVAIRIANT_CACHE_YEARS and \
+                                     self.config.end_year in EQUIVAIRIANT_CACHE_YEARS and \
+                                     self.config.start_year == self.config.end_year and \
+                                     self.config.delta_t in [2, 4, 6, 8, 12, 24] 
         # self.masks = masks.load_mask_hp(data_config.nside)
 
     @staticmethod
     def data_spec(config: DataHPConfig):
         return DataSpecHP(nside=config.nside, n_surface=4, n_upper=5)
+
+    @staticmethod
+    def collate_fn(batch):
+        """Collate that keeps 'time' as a list of datetimes (not a tensor)."""
+        from torch.utils.data.dataloader import default_collate
+        non_datetime = [{k: v for k, v in item.items() if k != "time"} for item in batch]
+        collated = default_collate(non_datetime)
+        collated["time"] = [item["time"] for item in batch]
+        return collated
 
     def e5_to_numpy(self, e5xr):
         if self.config.driscoll_healy:
@@ -440,7 +558,10 @@ class DataHP(torch.utils.data.Dataset):
         return dict(surface=surface_metas, upper=upper_metas)
 
     def get_cache_dir(self):
-        return env().paths.datasets / self.config.cache_name()
+        if not self.use_equivariant_cache:
+            return env().paths.datasets / self.config.cache_name()
+        else:
+            return env().paths.datasets / self.config.cache_name_equivariant()
 
     def get_statistics_path(self):
         return env().paths.datasets / f"{self.config.statistics_name()}.npy"
@@ -458,15 +579,138 @@ class DataHP(torch.utils.data.Dataset):
             )
 
     def __getitem__(self, idx):
-        if self.config.lead_time_days == 1:
-            return self._get_24h(idx)
+        
+        if self.use_equivariant_cache:
+            return self._get_th(idx)
+
         else:
-            sample = self._get_24h(idx)
-            target = self._get_24h(idx + self.config.lead_time_days - 1)
-            sample["target_surface"] = target["target_surface"]
-            sample["target_upper"] = target["target_upper"]
-            sample["prediction_timedelta_hours"] = 24 * self.config.lead_time_days
-            return sample
+            if self.config.lead_time_days == 1:
+                return self._get_24h(idx)
+            else:
+                sample = self._get_24h(idx)
+                target = self._get_24h(idx + self.config.lead_time_days - 1)
+                sample["target_surface"] = target["target_surface"]
+                sample["target_upper"] = target["target_upper"]
+                sample["prediction_timedelta_hours"] = 24 * self.config.lead_time_days
+                return sample
+
+    def ds_index_to_era5_config(self, ds_idx):
+        start = datetime(self.config.start_year, 1, 1, 0, 0, 0)
+        dt = start + timedelta(hours=ds_idx * 2)
+        year = str(dt.year)
+        month = str(dt.month).zfill(2)
+        day = str(dt.day).zfill(2)
+        time = dt.strftime("%H:%M:%S")
+
+        return cdstest.ERA5SampleConfig(year=year, month=month, day=day, time=time)
+
+    def load_sample(self, year:int , ds_idx: int, names: dict):
+        fs_cache_path = self.get_cache_dir() / f"year_{year}/{ds_idx}" 
+        fs_cache_path_tmp = self.get_cache_dir() / f"year_{year}/{ds_idx}_constructing"
+
+        if fs_cache_path.is_dir() and self.config.cache:
+            data_dict = dict()
+            for key, filename in names.items():
+                data_dict[key] = np.load(fs_cache_path / filename).astype(np.float32)
+            data_dict["time"] = json.loads(open(fs_cache_path / "era5_config.json").read())["time"]
+            data_dict["masks"] = masks.load_mask_hp(self.config.nside)
+            return data_dict
+
+
+        e5s_config = self.ds_index_to_era5_config(ds_idx)
+        # print("Get ERA5 sample")
+        
+        downloaded = False # Flag variable to eventually redownload corrupted samples
+
+        while not downloaded:
+            try:
+                e5s = cdstest.get_era5_sample(e5s_config)
+                downloaded = True
+            except Exception as e:
+                print(f"Error loading ERA5 sample for config: {e5s_config}")
+                print(e)
+                
+                # Deleting the .grib files associated with the sample to force redownloading, since the error is likely due to corrupted files
+                os.remove(e5s_config.surface_grib_path())
+                os.remove(e5s_config.upper_grib_path())
+
+                print("Retrying download...")
+
+
+        # print("Get ERA5 sample done")
+        hp_surface, hp_upper = self.e5_to_numpy(e5s)
+        # print("To numpy done")
+        data_dict = dict(
+            surface=hp_surface.astype(np.float32),
+            upper=hp_upper.astype(np.float32),
+        )
+        if self.config.cache:
+            fs_cache_path_tmp.mkdir(parents=True, exist_ok=True)
+            for key, filename in names.items():
+                np.save(fs_cache_path_tmp / filename, data_dict[key])
+
+            open(fs_cache_path_tmp / "era5_config.json", "w").write(
+                json.dumps(e5s_config.__dict__, indent=2)
+            )
+
+            if not fs_cache_path.is_dir():
+                shutil.move(fs_cache_path_tmp, fs_cache_path)
+
+        data_dict["time"] = e5s_config.time
+        data_dict["masks"] = masks.load_mask_hp(self.config.nside)
+    
+        return data_dict
+
+    def _get_th(self, idx):
+        idx = idx * self.config.delta_t // 2 # since the data is downloaded every 2 hours, we need to divide by 2 to get the correct index
+
+        year = self.config.start_year + idx // (12 * 365) # since there are (12 * 365) samples per year
+        year_target = year
+        ds_idx = idx % (12 * 365) # index within the year
+        ds_idx_target = ds_idx + self.config.delta_t // 2
+
+        if ds_idx == (12 * 365) - (self.config.delta_t // 2):
+            year_target += 1
+
+        names = dict(
+            surface="surface.npy",
+            upper="upper.npy",
+        )
+        item_dict = dict(
+            sample_id=ds_idx,
+            prediction_timedelta_hours=self.config.delta_t,
+        )
+
+        sample_dict = self.load_sample(year, ds_idx, names)
+        target_dict = self.load_sample(year_target, ds_idx_target, names)
+
+        if self.config.normalized:
+            stats = deserialize_dataset_statistics(self.config.nside).item()
+            for d in [sample_dict, target_dict]:
+                # Normalize on the fly if the cached data is in physical units.
+                # Cached entries built with normalized=False have surface values in
+                # the tens-of-thousands range (e.g. MSL pressure ~101325 Pa), whereas
+                # normalized values are always within a few sigma of zero.
+                if np.abs(d["surface"]).max() > 50:
+                    surf, upper = normalize_sample(stats, d["surface"], d["upper"])
+                    d["surface"] = surf.astype(np.float32)
+                    d["upper"] = upper.astype(np.float32)
+
+        input_dt = datetime(year, 1, 1, 0, 0, 0) + timedelta(hours=ds_idx * 2)
+
+        item_dict["input_surface"] = sample_dict["surface"]
+        item_dict["input_upper"] = sample_dict["upper"]
+        item_dict["target_surface"] = target_dict["surface"]
+        item_dict["target_upper"] = target_dict["upper"]
+        item_dict["time"] = input_dt
+        item_dict["masks"] = sample_dict["masks"]
+
+        return item_dict
+        
+        
+        
+
+
 
     def _get_24h(self, idx):
         if idx >= len(self):
@@ -481,13 +725,7 @@ class DataHP(torch.utils.data.Dataset):
         )
         item_dict = dict(
             sample_id=idx,
-            time=np.datetime_as_string(
-                np.datetime64(
-                    day_index_to_datetime(
-                        idx, self.config.start_year, self.config.end_year
-                    )
-                )
-            ),
+            time=day_index_to_datetime(idx, self.config.start_year, self.config.end_year),
             prediction_timedelta_hours=24,
         )
         done = False
@@ -543,7 +781,156 @@ class DataHP(torch.utils.data.Dataset):
         return item_dict
 
     def __len__(self):
-        return days_between_years(self.config.start_year, self.config.end_year)
+        return (days_between_years(self.config.start_year, self.config.end_year) - 1) * 24 // self.config.delta_t 
+    
+@dataclass
+class DataHPSubsetConfig:
+    data_config: DataHPConfig
+    reduction_factor: float = 0.1
+    consecutive_samples: int = 1
+
+class DataHPSubset(torch.utils.data.Dataset):
+    """
+    Since DataHP does not allow to use a subset of a year, this class allows to reduce the size of the dataset.
+    """
+
+    def __init__(self, config: DataHPSubsetConfig):
+        """
+        Args:
+            data_config: Configuration for the data
+            reduction_factor: Factor by which to reduce the dataset size (0,1] - e.g. 0.1 will use 10% of the data
+            consecutive_samples: Number of consecutive samples to include in the subset.
+
+        Example:
+            reduction_factor = 0.1, consecutive_samples = 5
+            -> keep 5 consecutive samples, then skip about 45, repeating through each year.
+        """
+        self.original_dataset = DataHP(config.data_config)
+
+        if config.reduction_factor <= 0 or config.reduction_factor > 1:
+            raise ValueError("reduction_factor must be in the range (0, 1]")
+        self.reduction_factor = config.reduction_factor
+
+        if config.consecutive_samples < 1:
+            raise ValueError("consecutive_samples must be at least 1")
+        self.consecutive_samples = config.consecutive_samples
+
+        self._subset_indices = self._build_subset_indices()
+
+        self.config = config.data_config
+
+    def _build_subset_indices(self):
+        total_len = len(self.original_dataset)
+        n_years = self.original_dataset.config.end_year - self.original_dataset.config.start_year + 1
+
+        # Split the total dataset length across years.
+        # This is robust even if total_len is not perfectly divisible by n_years.
+        base_year_len = total_len // n_years
+        remainder = total_len % n_years
+
+        year_lengths = [
+            base_year_len + (1 if i < remainder else 0)
+            for i in range(n_years)
+        ]
+
+        subset_indices = []
+        offset = 0
+
+        for year_len in year_lengths:
+            target_kept = int(year_len * self.reduction_factor)
+
+            if target_kept == 0 and year_len > 0:
+                target_kept = 1
+
+            # If reduction_factor = kept / cycle_len  => cycle_len ~= kept_block / reduction_factor
+            cycle_len = max(
+                self.consecutive_samples,
+                round(self.consecutive_samples / self.reduction_factor)
+            )
+
+            kept = 0
+            cursor = 0
+
+            while kept < target_kept and cursor < year_len:
+                take = min(
+                    self.consecutive_samples,
+                    target_kept - kept,
+                    year_len - cursor
+                )
+
+                subset_indices.extend(range(offset + cursor, offset + cursor + take))
+
+                kept += take
+                cursor += cycle_len
+
+            offset += year_len
+
+        return subset_indices
+
+    def __getitem__(self, idx):
+        real_idx = self._subset_indices[idx]
+        return self.original_dataset[real_idx]
+
+    def __len__(self):
+        return len(self._subset_indices)
+
+    @staticmethod
+    def collate_fn(batch):
+        return DataHP.collate_fn(batch)
+
+class DataHPConvConfig(DataHPConfig):
+    input_time_dim: int = 1 # Number of input time steps
+    output_time_dim: int = 1 # Number of output time steps
+
+    def short_name(self):
+        return super().short_name() + "_conv"
+
+class DataHPConv(DataHP):
+    """
+    This dataset is designed to provide multiple time steps of input data for convolutional models, which can leverage temporal information. 
+    It extends the DataHP class to include a sequence of input time steps (input_time_dim) and a single output time step (output_time_dim). 
+    The __getitem__ method is overridden to return a sequence of input data and the corresponding target data for the specified time steps.
+    """
+
+    def __init__(self, data_config: DataHPConvConfig):
+        super().__init__(data_config)
+
+    
+    def __getitem__(self, idx):
+        input_time_dim = self.config.input_time_dim
+        output_time_dim = self.config.output_time_dim
+
+        if idx >= len(self):
+            raise StopIteration()
+
+        input_sequence = []
+        for i in range(input_time_dim):
+            input_sequence.append(super().__getitem__(idx + i))
+        
+        target_sequence = []
+        for i in range(output_time_dim):
+            target_sequence.append(super().__getitem__(idx + input_time_dim + i))
+
+        # Stack the input sequence along a new time dimension
+        input_surface_sequence = np.stack([item['input_surface'] for item in input_sequence], axis=0) # Shape: (input_time_dim, n_channels, n_pix)
+        input_upper_sequence = np.stack([item['input_upper'] for item in input_sequence], axis=0) # Shape: (input_time_dim, n_channels, n_pix)
+        target_surface_sequence = np.stack([item['target_surface'] for item in target_sequence], axis=0) # Shape: (output_time_dim, n_channels, n_pix)
+        target_upper_sequence = np.stack([item['target_upper'] for item in target_sequence], axis=0) # Shape: (output_time_dim, n_channels, n_pix)
+
+        
+
+        return {
+            'sample_id': idx,
+            'input_surface': input_surface_sequence,
+            'input_upper': input_upper_sequence,
+            'target_surface': target_surface_sequence,
+            'target_upper': target_upper_sequence,
+            'prediction_timedelta_hours': target_sequence[0]['prediction_timedelta_hours'],
+        }
+
+    def __len__(self):
+        # The length is reduced by the number of input and output time steps to ensure we don't go out of bounds
+        return super().__len__() - self.config.input_time_dim - self.config.output_time_dim + 1
 
 
 def deserialize_dataset_statistics(nside):
@@ -690,3 +1077,40 @@ def serialize_dataset_statistics(nside, test_with_one_sample=False):
     ds.get_cache_dir().mkdir(parents=True, exist_ok=True)
     np.save(ds.get_statistics_path(), statistics_dict)
     print(f"Saved npy {ds.get_statistics_path()}")
+
+
+if __name__ == "__main__":
+
+    # for year in [2019]:
+    #     print(f"Checking year {year} for NaN values")
+
+    #     cnf2 = DataHPConfig(nside=64, start_year=year, end_year=year, normalized=False, delta_t=2)
+    #     ds = DataHP(cnf2)
+
+
+    #     for i in [48, 85, 564, 1128, 1476, 2184]:
+    #         corrupted_sample = ds[i]
+
+    #         # Localize where is the nan value in the corrupted sample
+    #         input_surface = corrupted_sample["input_surface"]
+    #         input_upper = corrupted_sample["input_upper"]
+
+    #         if np.isnan(input_surface).any():
+    #             print("NaN values found in input_surface")
+    #             nan_indices = np.argwhere(np.isnan(input_surface))
+    #             print(f"NaN indices in input_surface: {nan_indices}")
+    #         if np.isnan(input_upper).any():
+    #             print("NaN values found in input_upper")
+    #             nan_indices = np.argwhere(np.isnan(input_upper))
+    #             print(f"NaN indices in input_upper: {nan_indices}")
+    #             print(f"Number of NaN values in input_upper: {input_upper[nan_indices[:, 0], nan_indices[:, 1], nan_indices[:, 2]].size}")
+
+    print("Testing subset")
+    cnf = DataHPConfig(nside=64, start_year=2012, end_year=2012, delta_t=2)
+    climate_ds = Climatology(cnf, use_wb2_clim=True)
+
+    for i in range(len(climate_ds)):
+        sample = climate_ds[i]
+        print(sample["climate_target_surface"].shape, sample["climate_target_upper"].shape)
+
+    


### PR DESCRIPTION
## Summary
            
  - DataHPConfig.delta_t: new field (default 24h)
  enabling 2/4/6/12/24-hour sampling intervals for     
  SO(2)-symmetric training                        
  - DataHP._get_th() + __len__: new sampling path that 
  respects delta_t; dataset length scales with the    
  chosen interval                                                                         
  - New helpers: index_to_datetime,
  datetime_to_dataset_index,       
  index_to_climatology_indices for finer-grained time  
  indexing                                           
  - Climatology: wired up use_wb2_clim flag to plug in 
  the new WB2 reader                                  
  - DataHPSubset / DataHPSubsetConfig: train on a
  configurable fraction of the dataset with      
  consecutive-sample blocks                            
  - climatology_wb2.py (new): WeatherBench2 Zarr
  climatology reader with bilinear interpolation to    
  HEALPix pixels (any nside)  
